### PR TITLE
anl mirror service  disabled public access on Feb 1 2015

### DIFF
--- a/core-autodeploy.sh
+++ b/core-autodeploy.sh
@@ -132,7 +132,7 @@ fi
 # Defaults for user provided input
 arch="x86_64"
 # ftp mirror for MySQL to use for version auto-detection:
-mysql_ftp_mirror="ftp://mirror.anl.gov/pub/mysql/Downloads/MySQL-5.5/"
+mysql_ftp_mirror="http://mirror.sfo12.us.leaseweb.net/mysql/Downloads/MySQL-5.5/"
 
 # Auto-detect latest build:
 build=4.2.5-2108


### PR DESCRIPTION
replaced anl with leaseweb
